### PR TITLE
omit a definition of the node

### DIFF
--- a/GNN-tutorial.ipynb
+++ b/GNN-tutorial.ipynb
@@ -78,7 +78,7 @@
     "from torch_geometric.data import Data\n",
     "\n",
     "edge_index = torch.tensor([[1, 2, 3], [0, 0, 0]], dtype=torch.long)\n",
-    "x = torch.tensor([[1], [1], [1]], dtype=torch.float)\n",
+    "x = torch.tensor([[1], [1], [1], [1]], dtype=torch.float)\n",
     "\n",
     "data = Data(edge_index=edge_index, x=x)\n",
     "data"


### PR DESCRIPTION
As you depicted in the Figure, there are four nods, each with 1-dim feature scalar, but definition part only has `[[1], [1], [1]]`. So I revise it to `[[1], [1], [1], [1]]`